### PR TITLE
fix: add function to return empty object in options prop of Lenis.vue…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "nuxt-lenis",
-   "version": "1.1.0-beta.13",
+   "version": "1.1.1",
    "license": "MIT",
    "type": "module",
    "repository": {

--- a/src/runtime/components/lenis.vue
+++ b/src/runtime/components/lenis.vue
@@ -29,7 +29,7 @@ const emit = defineEmits(["scroll", "initiated"]);
 const props = defineProps({
    options: {
       type: Object,
-      default: {},
+      default: () => {},
    },
 });
 

--- a/src/runtime/components/lenis.vue
+++ b/src/runtime/components/lenis.vue
@@ -138,7 +138,5 @@ html.lenis {
 .lenis.lenis-scrolling iframe {
    pointer-events: none;
 }
-#test {
-   width: 90vw;
-}
+
 </style>


### PR DESCRIPTION
First: Thank you a lot for this module!

Today i just encountered an issue, when lenis is running in a project that uses vue-docgen (Storybook for Nuxt for example)
```
A default value needs to be a function when your type is an object or array
```

This PR will resolve this issue

Best,
Luca